### PR TITLE
Parse pinecone key

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -134,7 +134,9 @@ func recordPayload(payload sdk.Change) ([]float32, error) {
 func recordMetadata(data sdk.Metadata) (*pinecone.Metadata, error) {
 	convertedMap := make(map[string]interface{})
 	for key, value := range data {
-		convertedMap[key] = value
+		if trimmed, hasPrefix := trimPineconeKey(key); hasPrefix {
+			convertedMap[trimmed] = value
+		}
 	}
 	metadata, err := structpb.NewStruct(convertedMap)
 	if err != nil {
@@ -142,4 +144,14 @@ func recordMetadata(data sdk.Metadata) (*pinecone.Metadata, error) {
 	}
 
 	return metadata, nil
+}
+
+var keyPrefix = "pinecone."
+
+func trimPineconeKey(key string) (trimmed string, hasPrefix bool) {
+	if strings.HasPrefix(key, keyPrefix) {
+		return key[len(keyPrefix):], true
+	}
+
+	return key, false
 }


### PR DESCRIPTION
### Description

Parses "pinecone." prefix from sdk metadata.

The current thought model for the accepted sdk record would be something like this:

![image](https://github.com/conduitio-labs/conduit-connector-pinecone/assets/16207732/87fbc9d4-f6d6-4458-8b82-928fa63db0e7)
