### PR TITLE
Add stronger linter settings and integration tests to ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
           GOLANGCI_LINT_VERSION=$( go list -m -f '{{.Version}}' github.com/golangci/golangci-lint )
           echo "v=$GOLANGCI_LINT_VERSION" >> "$GITHUB_OUTPUT"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ steps.golangci-lint-version.outputs.v }}
           skip-pkg-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
 
 jobs:
-  test-activemq:
+  test-pinecone:
+    environment: ci  # Add this line
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,6 @@ jobs:
 
       - name: Run all tests
         run: make test
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+          HOST_URL: ${{ secrets.HOST_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: build
+name: test
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test-activemq:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,5 +16,5 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Test
-        run: make test-integration GOTEST_FLAGS="-v -count=1"
+      - name: Run all tests
+        run: make test

--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -1,0 +1,24 @@
+name: validate-generated-files
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  validate-generated-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Check generated files
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          make install-tools generate
+          git diff
+          git diff --exit-code --numstat

--- a/.golangci.goheader.template
+++ b/.golangci.goheader.template
@@ -1,0 +1,13 @@
+Copyright © {{ copyright-year }} Meroxa, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,7 @@
+run:
+  timeout: 5m
+
 linters-settings:
-  gofmt:
-    simplify: false
-  govet:
-    check-shadowing: false
   nolintlint:
     allow-unused: false # report any unused nolint directives
     require-explanation: true # require an explanation for nolint directives
@@ -11,70 +10,107 @@ linters-settings:
     min-complexity: 20
   goconst:
     ignore-tests: true
+  goheader:
+    template-path: '.golangci.goheader.template'
+    values:
+      regexp:
+        copyright-year: 20[2-9]\d
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dogsled
+        - gosec
+        - gocognit
+        - errcheck
+        - forcetypeassert
+        - funlen
+        - goerr113
+        - dupl
+        - prealloc
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
+    - asasalint
+    - asciicheck
+    - bidichk
     - bodyclose
+    - containedctx
+    - contextcheck
+    - decorder
     # - depguard
     - dogsled
+    - dupl
+    - dupword
     - durationcheck
     - errcheck
+    - errchkjson
     - errname
-    # - errorlint
-    # - exhaustive
-    # - exhaustivestruct
+    - errorlint
+    - execinquery
+    - exhaustive
     - exportloopref
     # - forbidigo
-    # - forcetypeassert
-    # - funlen
-    # - gochecknoinits
+    - forcetypeassert
+    - funlen
+    - gci
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecknoinits
+    - gocognit
     - goconst
     - gocritic
-    - gocyclo
-    # - cyclop # not interested in package complexities at the moment
-    # - godot
+    - godot
+    # - goerr113
     - gofmt
-    # - gofumpt
+    - gofumpt
     - goheader
     - goimports
-    # - revive # lots of unused parameters in the template, would be helpful for the user to keep them
-    # - gomnd
     - gomoddirectives
-    - gomodguard
     - goprintffuncname
     - gosec
     - gosimple
+    - gosmopolitan
     - govet
-    # - ifshort
+    - grouper
+    - importas
     - ineffassign
-    # - importas
-    # - lll
-    # - misspell
+    - interfacebloat
+    # - ireturn # Doesn't have correct support for generic types https://github.com/butuzov/ireturn/issues/37
+    - loggercheck
+    - maintidx
     - makezero
-    # - nakedret
-    # - nilerr
-    # - nilnil
-    # - nlreturn
+    - mirror
+    - misspell
+    - musttag
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
     - noctx
     - nolintlint
-    # - paralleltest
+    - nosprintfhostport
+    - prealloc
     - predeclared
-    # - rowserrcheck
+    - promlinter
+    - reassign
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
     - staticcheck
     - stylecheck
-    # - sqlclosecheck
-    # - tagliatelle
-    # - tenv
+    - tenv
+    - testableexamples
     # - thelper
-    # - tparallel
-    - typecheck
     - unconvert
-    # - unparam
+    - unparam
     - unused
-    # - wastedassign
+    - usestdlibvars
+    - wastedassign
     - whitespace
-    # - wrapcheck
-    # - wsl
+    - wrapcheck
+    - zerologlint

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,7 @@ build:
 	go build -ldflags "-X 'github.com/conduitio/conduit-connector-pinecone.version=${VERSION}'" -o conduit-connector-pinecone cmd/connector/main.go
 
 test:
-	go test $(GOTEST_FLAGS) -race ./...
-
-test-integration:
-	# run required docker containers, execute integration tests, stop containers after tests
-	docker compose -f test/docker-compose.yml up -d
-	go test $(GOTEST_FLAGS) -v -race ./...; ret=$$?; \
-		docker compose -f test/docker-compose.yml down; \
-		exit $$ret
+	go test -v -race ./...
 
 generate:
 	go generate ./...

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -1,9 +1,22 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
-	sdk "github.com/conduitio/conduit-connector-sdk"
-
 	pinecone "github.com/conduitio-labs/conduit-connector-pinecone"
+	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 
 func main() {

--- a/connector.go
+++ b/connector.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pinecone
 
 import (

--- a/destination.go
+++ b/destination.go
@@ -44,9 +44,9 @@ type DestinationConfig struct {
 
 func (d DestinationConfig) toMap() map[string]string {
 	return map[string]string{
-		"pinecone.apiKey":    d.APIKey,
-		"pinecone.host":      d.Host,
-		"pinecone.namespace": d.Namespace,
+		"apiKey":    d.APIKey,
+		"host":      d.Host,
+		"namespace": d.Namespace,
 	}
 }
 

--- a/destination.go
+++ b/destination.go
@@ -67,12 +67,11 @@ func (d *Destination) Configure(ctx context.Context, cfg map[string]string) erro
 	return nil
 }
 
-func (d *Destination) Open(ctx context.Context) error {
-	newWriter, err := NewWriter(ctx, d.config)
+func (d *Destination) Open(ctx context.Context) (err error) {
+	d.writer, err = NewWriter(ctx, d.config)
 	if err != nil {
 		return fmt.Errorf("error creating a new writer: %w", err)
 	}
-	d.writer = newWriter
 
 	sdk.Logger(ctx).Info().Msg("created pinecone destination")
 

--- a/destination.go
+++ b/destination.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pinecone
 
 //go:generate paramgen -output=paramgen_dest.go DestinationConfig
@@ -5,6 +19,7 @@ package pinecone
 import (
 	"context"
 	"fmt"
+
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 

--- a/destination_test.go
+++ b/destination_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pinecone
 
 import (
@@ -36,7 +50,7 @@ func TestDestination_NamespaceSet(t *testing.T) {
 
 	err = dest.Open(ctx)
 	is.NoErr(err)
-	defer teardown(is, ctx, dest)
+	defer teardown(ctx, is, dest)
 
 	is.Equal(dest.writer.index.Namespace, "test-namespace")
 }
@@ -52,7 +66,7 @@ func TestDestination_Integration_WriteDelete(t *testing.T) {
 
 	err = dest.Open(ctx)
 	is.NoErr(err)
-	defer teardown(is, ctx, dest)
+	defer teardown(ctx, is, dest)
 
 	id := uuid.NewString()
 	position := sdk.Position(fmt.Sprintf("pos-%v", id))
@@ -62,7 +76,7 @@ func TestDestination_Integration_WriteDelete(t *testing.T) {
 	}
 
 	vecsToBeWritten := recordPayload{
-		Id:     id,
+		ID:     id,
 		Values: []float32{1, 2},
 	}
 
@@ -73,35 +87,35 @@ func TestDestination_Integration_WriteDelete(t *testing.T) {
 	_, err = dest.Write(ctx, []sdk.Record{rec})
 	is.NoErr(err)
 
-	assertWrittenRecordIndex(t, is, ctx, dest.writer.index, id, vecsToBeWritten)
+	assertWrittenRecordIndex(ctx, t, is, dest.writer.index, id, vecsToBeWritten)
 
 	rec = sdk.Util.Source.NewRecordDelete(position, metadata, sdk.RawData(id))
 	_, err = dest.Write(ctx, []sdk.Record{rec})
+	is.NoErr(err)
 
-	assertDeletedRecordIndex(t, is, ctx, dest.writer.index, id)
+	assertDeletedRecordIndex(ctx, t, is, dest.writer.index, id)
 
 	deleteAllRecords(is, dest.writer.index)
 }
 
-const MAX_RETRIES = 3
+const maxRetries = 3
 
 func waitTime(i int) time.Duration {
 	wait := math.Pow(2, float64(i))
 	return time.Duration(wait) * time.Second
 }
 
-func assertWrittenRecordIndex(t *testing.T, is *is.I, ctx context.Context, index *pinecone.IndexConnection, id string, writtenVecs recordPayload) {
-
+func assertWrittenRecordIndex(ctx context.Context, t *testing.T, is *is.I, index *pinecone.IndexConnection, id string, writtenVecs recordPayload) {
 	// Pinecone writes appear to be asynchronous. At the very least, in the current free tier serverless
 	// configuration that I've tested, pinecone writes occurred slightly after the RPC call
 	// returned data. Therefore, the following retry logic is needed to make tests more robust
-	for i := 1; i <= MAX_RETRIES; i++ {
+	for i := 1; i <= maxRetries; i++ {
 		res, err := index.FetchVectors(&ctx, []string{id})
 		is.NoErr(err)
 
 		vec, ok := res.Vectors[id]
 		if !ok {
-			if i == MAX_RETRIES {
+			if i == maxRetries {
 				is.Fail() // vector was not written
 			} else {
 				wait := waitTime(i)
@@ -116,15 +130,15 @@ func assertWrittenRecordIndex(t *testing.T, is *is.I, ctx context.Context, index
 	}
 }
 
-func assertDeletedRecordIndex(t *testing.T, is *is.I, ctx context.Context, index *pinecone.IndexConnection, id string) {
+func assertDeletedRecordIndex(ctx context.Context, t *testing.T, is *is.I, index *pinecone.IndexConnection, id string) {
 	// same as assertWrittenRecordIndex, we need the retry for robustness
-	for i := 0; i <= MAX_RETRIES; i++ {
+	for i := 0; i <= maxRetries; i++ {
 		res, err := index.FetchVectors(&ctx, []string{id})
 		is.NoErr(err)
 
 		_, ok := res.Vectors[id]
 		if ok {
-			if i == MAX_RETRIES {
+			if i == maxRetries {
 				is.Fail() // vector found, not properly deleted
 			} else {
 				wait := waitTime(i)
@@ -152,7 +166,7 @@ type connectorResource interface {
 	Teardown(ctx context.Context) error
 }
 
-func teardown(is *is.I, ctx context.Context, resource connectorResource) {
+func teardown(ctx context.Context, is *is.I, resource connectorResource) {
 	err := resource.Teardown(ctx)
 	is.NoErr(err)
 }

--- a/destination_test.go
+++ b/destination_test.go
@@ -30,16 +30,26 @@ import (
 	"github.com/pinecone-io/go-pinecone/pinecone"
 )
 
-func destConfigFromEnv() DestinationConfig {
+func destConfigFromEnv(t *testing.T) DestinationConfig {
 	return DestinationConfig{
-		APIKey: os.Getenv("API_KEY"),
-		Host:   os.Getenv("HOST_URL"),
+		APIKey: requiredEnv(t, "API_KEY"),
+		Host:   requiredEnv(t, "HOST_URL"),
 	}
+}
+
+func requiredEnv(t *testing.T, key string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		t.Fatalf("env var %v unset", key)
+	}
+
+	return val
 }
 
 func TestDestination_NamespaceSet(t *testing.T) {
 	ctx := context.Background()
-	destCfg := destConfigFromEnv()
+	destCfg := destConfigFromEnv(t)
+	// we use the default namespace on all other tests, so it's correct to set it here
 	destCfg.Namespace = "test-namespace"
 
 	is := is.New(t)
@@ -57,7 +67,7 @@ func TestDestination_NamespaceSet(t *testing.T) {
 
 func TestDestination_Integration_WriteDelete(t *testing.T) {
 	ctx := context.Background()
-	destCfg := destConfigFromEnv()
+	destCfg := destConfigFromEnv(t)
 	is := is.New(t)
 	dest := newDestination()
 

--- a/destination_test.go
+++ b/destination_test.go
@@ -98,7 +98,7 @@ func TestDestination_Integration_WriteDelete(t *testing.T) {
 	deleteAllRecords(is, dest.writer.index)
 }
 
-const maxRetries = 3
+const maxRetries = 4
 
 func waitTime(i int) time.Duration {
 	wait := math.Pow(2, float64(i))

--- a/destination_test.go
+++ b/destination_test.go
@@ -78,6 +78,10 @@ func TestDestination_Integration_WriteDelete(t *testing.T) {
 	vecsToBeWritten := recordPayload{
 		ID:     id,
 		Values: []float32{1, 2},
+		SparseValues: sparseValues{
+			Indices: []uint32{3, 5},
+			Values:  []float32{0.5, 0.3},
+		},
 	}
 
 	payload, err := json.Marshal(vecsToBeWritten)
@@ -126,6 +130,8 @@ func assertWrittenRecordIndex(ctx context.Context, t *testing.T, is *is.I, index
 		}
 
 		is.Equal(vec.Values, writtenVecs.Values)
+		is.Equal(vec.SparseValues.Values, writtenVecs.SparseValues.Values)
+		is.Equal(vec.SparseValues.Indices, writtenVecs.SparseValues.Indices)
 		break
 	}
 }

--- a/paramgen_dest.go
+++ b/paramgen_dest.go
@@ -9,25 +9,25 @@ import (
 
 func (DestinationConfig) Parameters() map[string]sdk.Parameter {
 	return map[string]sdk.Parameter{
-		"pinecone.apiKey": {
+		"apiKey": {
 			Default:     "",
-			Description: "pinecone.apiKey is the API Key for authenticating with Pinecone.",
+			Description: "apiKey is the API Key for authenticating with Pinecone.",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
 			},
 		},
-		"pinecone.host": {
+		"host": {
 			Default:     "",
-			Description: "pinecone.host is the Pinecone index host URL",
+			Description: "host is the Pinecone index host URL",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
 			},
 		},
-		"pinecone.namespace": {
+		"namespace": {
 			Default:     "",
-			Description: "pinecone.namespace is the Pinecone's index namespace. Defaults to the empty namespace.",
+			Description: "namespace is the Pinecone's index namespace. Defaults to the empty namespace.",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{},
 		},

--- a/paramgen_dest.go
+++ b/paramgen_dest.go
@@ -25,5 +25,11 @@ func (DestinationConfig) Parameters() map[string]sdk.Parameter {
 				sdk.ValidationRequired{},
 			},
 		},
+		"pinecone.namespace": {
+			Default:     "",
+			Description: "pinecone.namespace is the Pinecone's index namespace. Defaults to the empty namespace.",
+			Type:        sdk.ParameterTypeString,
+			Validations: []sdk.Validation{},
+		},
 	}
 }

--- a/spec.go
+++ b/spec.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pinecone
 
 import (

--- a/tools.go
+++ b/tools.go
@@ -17,5 +17,6 @@
 package pinecone
 
 import (
+	_ "github.com/conduitio/conduit-connector-sdk/cmd/paramgen"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 )

--- a/writer.go
+++ b/writer.go
@@ -79,7 +79,7 @@ func (w *Writer) Upsert(ctx context.Context, record sdk.Record) error {
 		//revive:disable-next-line
 		Id:     id,
 		Values: payload.Values,
-		// SparseValues: payload.PineconeSparseValues(),
+		SparseValues: payload.PineconeSparseValues(),
 		Metadata: metadata,
 	}
 

--- a/writer.go
+++ b/writer.go
@@ -62,46 +62,20 @@ func NewWriter(ctx context.Context, config DestinationConfig) (*Writer, error) {
 	return &w, nil
 }
 
-func (w *Writer) Upsert(ctx context.Context, record sdk.Record) error {
-	id := recordID(record.Key)
-
-	payload, err := parseRecordPayload(record.Payload)
+func (w *Writer) UpsertVectors(ctx context.Context, vectors []*pinecone.Vector) (int, error) {
+	upserted, err := w.index.UpsertVectors(&ctx, vectors)
 	if err != nil {
-		return fmt.Errorf("error getting payload: %w", err)
+		return int(upserted), fmt.Errorf("error upserting record: %w", err)
 	}
 
-	metadata, err := recordMetadata(record.Metadata)
-	if err != nil {
-		return fmt.Errorf("error getting metadata: %w", err)
-	}
-
-	vec := &pinecone.Vector{
-		//revive:disable-next-line
-		Id:           id,
-		Values:       payload.Values,
-		SparseValues: payload.PineconeSparseValues(),
-		Metadata:     metadata,
-	}
-
-	_, err = w.index.UpsertVectors(&ctx, []*pinecone.Vector{vec})
-	if err != nil {
-		return fmt.Errorf("error upserting record: %w", err)
-	}
-	sdk.Logger(ctx).Trace().Msgf("upserted record id %s", id)
-
-	return nil
+	return int(upserted), nil
 }
 
-// Delete deletes records by a key.
-func (w *Writer) Delete(ctx context.Context, record sdk.Record) error {
-	id := recordID(record.Key)
-	ids := []string{id}
-
-	err := w.index.DeleteVectorsById(&ctx, ids)
+func (w *Writer) DeleteVectorsByID(ctx context.Context, vectorIDs []string) error {
+	err := w.index.DeleteVectorsById(&ctx, vectorIDs)
 	if err != nil {
 		return fmt.Errorf("error deleting record: %w", err)
 	}
-	sdk.Logger(ctx).Trace().Msgf("deleted record %v", id)
 
 	return nil
 }
@@ -127,7 +101,6 @@ type recordPayload struct {
 	ID           string       `json:"id"`
 	Values       []float32    `json:"values"`
 	SparseValues sparseValues `json:"sparse_values,omitempty"`
-	Namespace    string       `json:"namespace"`
 }
 
 func (r recordPayload) PineconeSparseValues() *pinecone.SparseValues {
@@ -144,8 +117,32 @@ func (r recordPayload) PineconeSparseValues() *pinecone.SparseValues {
 	return v
 }
 
-func parseRecordPayload(payload sdk.Change) (parsed recordPayload, err error) {
-	data := payload.After
+func parseVector(rec sdk.Record) (*pinecone.Vector, error) {
+	id := recordID(rec.Key)
+
+	payload, err := parseRecordPayload(rec)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata, err := parsePineconeMetadata(rec)
+	if err != nil {
+		return nil, err
+	}
+
+	vec := &pinecone.Vector{
+		//revive:disable-next-line
+		Id:           id,
+		Values:       payload.Values,
+		SparseValues: payload.PineconeSparseValues(),
+		Metadata:     metadata,
+	}
+
+	return vec, nil
+}
+
+func parseRecordPayload(rec sdk.Record) (parsed recordPayload, err error) {
+	data := rec.Payload.After
 
 	if data == nil || len(data.Bytes()) == 0 {
 		return parsed, errors.New("empty payload")
@@ -159,9 +156,9 @@ func parseRecordPayload(payload sdk.Change) (parsed recordPayload, err error) {
 	return parsed, nil
 }
 
-func recordMetadata(data sdk.Metadata) (*pinecone.Metadata, error) {
+func parsePineconeMetadata(rec sdk.Record) (*pinecone.Metadata, error) {
 	convertedMap := make(map[string]any)
-	for key, value := range data {
+	for key, value := range rec.Metadata {
 		if trimmed, hasPrefix := trimPineconeKey(key); hasPrefix {
 			convertedMap[trimmed] = value
 		}
@@ -182,4 +179,74 @@ func trimPineconeKey(key string) (trimmed string, hasPrefix bool) {
 	}
 
 	return key, false
+}
+
+type recordBatch interface {
+	writeBatch(context.Context, *Writer) (int, error)
+}
+
+type upsertBatch struct {
+	vectors []*pinecone.Vector
+}
+
+func (b upsertBatch) writeBatch(ctx context.Context, writer *Writer) (int, error) {
+	return writer.UpsertVectors(ctx, b.vectors)
+}
+
+type deleteBatch struct {
+	ids []string
+}
+
+func (b deleteBatch) writeBatch(ctx context.Context, writer *Writer) (int, error) {
+	err := writer.DeleteVectorsByID(ctx, b.ids)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(b.ids), nil
+}
+
+// buildBatches processes a slice of records and groups them into batches based
+// on their operation type. New batches are started whenever the operation type
+// switches from upsert to delete or vice versa.
+// Records are batched this way so that we preserve conduit's requirement of writing
+// records sequentially.
+func buildBatches(records []sdk.Record) ([]recordBatch, error) {
+	var batches []recordBatch
+	var currUpsertBatch upsertBatch
+	var currDeleteBatch deleteBatch
+
+	for i, rec := range records {
+		isLast := i == len(records)-1
+		switch rec.Operation {
+		case sdk.OperationCreate, sdk.OperationUpdate, sdk.OperationSnapshot:
+			vec, err := parseVector(rec)
+			if err != nil {
+				return nil, err
+			}
+
+			currUpsertBatch.vectors = append(currUpsertBatch.vectors, vec)
+
+			if isLast {
+				batches = append(batches, currUpsertBatch)
+			}
+			if len(currDeleteBatch.ids) != 0 {
+				batches = append(batches, currDeleteBatch)
+				currDeleteBatch = deleteBatch{}
+			}
+		case sdk.OperationDelete:
+			id := recordID(rec.Key)
+			currDeleteBatch.ids = append(currDeleteBatch.ids, id)
+
+			if isLast {
+				batches = append(batches, currDeleteBatch)
+			}
+			if len(currUpsertBatch.vectors) != 0 {
+				batches = append(batches, currUpsertBatch)
+				currUpsertBatch = upsertBatch{}
+			}
+		}
+	}
+
+	return batches, nil
 }

--- a/writer.go
+++ b/writer.go
@@ -77,10 +77,10 @@ func (w *Writer) Upsert(ctx context.Context, record sdk.Record) error {
 
 	vec := &pinecone.Vector{
 		//revive:disable-next-line
-		Id:     id,
-		Values: payload.Values,
+		Id:           id,
+		Values:       payload.Values,
 		SparseValues: payload.PineconeSparseValues(),
-		Metadata: metadata,
+		Metadata:     metadata,
 	}
 
 	_, err = w.index.UpsertVectors(&ctx, []*pinecone.Vector{vec})

--- a/writer_test.go
+++ b/writer_test.go
@@ -15,7 +15,6 @@
 package pinecone
 
 import (
-	"fmt"
 	"testing"
 
 	sdk "github.com/conduitio/conduit-connector-sdk"
@@ -25,16 +24,72 @@ import (
 func TestRecordMetadata(t *testing.T) {
 	is := is.New(t)
 
-	sdkMetadata := sdk.Metadata{
+	var rec sdk.Record
+	rec.Metadata = sdk.Metadata{
 		"created_at":     "2023-03-15T14:25:07Z",
 		"pinecone.prop1": "a1",
 		"pinecone.prop2": "a2",
 	}
-	recMetadata, err := recordMetadata(sdkMetadata)
+	recMetadata, err := parsePineconeMetadata(rec)
 	is.NoErr(err)
-
-	fmt.Println()
 
 	is.Equal(recMetadata.Fields["prop1"].AsInterface().(string), "a1")
 	is.Equal(recMetadata.Fields["prop2"].AsInterface().(string), "a2")
+}
+
+func testRecord(op sdk.Operation) sdk.Record {
+	var position sdk.Position
+	var key sdk.Data = sdk.RawData("key")
+	var metadata sdk.Metadata
+	var payload sdk.Data = sdk.StructuredData{
+		"vector": []float64{1, 2},
+	}
+
+	return sdk.Record{
+		Position: position, Operation: op,
+		Metadata: metadata, Key: key,
+		Payload: sdk.Change{
+			Before: nil,
+			After:  payload,
+		},
+	}
+}
+
+func batchSize(batch recordBatch) int {
+	switch batch := batch.(type) {
+	case upsertBatch:
+		return len(batch.vectors)
+	case deleteBatch:
+		return len(batch.ids)
+	}
+
+	panic("invalid batch")
+}
+
+func TestParseRecords(t *testing.T) {
+	is := is.New(t)
+
+	records := []sdk.Record{
+		testRecord(sdk.OperationUpdate),
+
+		testRecord(sdk.OperationDelete), testRecord(sdk.OperationDelete),
+
+		testRecord(sdk.OperationCreate), testRecord(sdk.OperationCreate),
+		testRecord(sdk.OperationCreate),
+
+		testRecord(sdk.OperationDelete),
+
+		testRecord(sdk.OperationSnapshot), testRecord(sdk.OperationSnapshot),
+	}
+
+	batches, err := buildBatches(records)
+	is.NoErr(err)
+
+	is.Equal(len(batches), 5)
+
+	is.Equal(batchSize(batches[0]), 1)
+	is.Equal(batchSize(batches[1]), 2)
+	is.Equal(batchSize(batches[2]), 3)
+	is.Equal(batchSize(batches[3]), 1)
+	is.Equal(batchSize(batches[4]), 2)
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pinecone
 
 import (


### PR DESCRIPTION
### Description

Stacked from #19 

- Stronger linter setup
- Integration tests on CI
    - @simonl2002 we need `API_KEY` and `HOST_URL` env vars as encrypted secrets on an environment named `ci`. 