### PR TITLE
Add record batching

### DIFF
--- a/destination.go
+++ b/destination.go
@@ -89,7 +89,7 @@ func (d *Destination) Write(ctx context.Context, records []sdk.Record) (int, err
 		batchWrittenRecs, err := batch.writeBatch(ctx, d.writer)
 		written += batchWrittenRecs
 		if err != nil {
-			return written, err
+			return written, fmt.Errorf("failed to write record batch: %w", err)
 		}
 	}
 

--- a/destination.go
+++ b/destination.go
@@ -79,7 +79,7 @@ func (d *Destination) Open(ctx context.Context) (err error) {
 }
 
 func (d *Destination) Write(ctx context.Context, records []sdk.Record) (int, error) {
-	batches, err := parseRecords(records)
+	batches, err := buildBatches(records)
 	if err != nil {
 		return 0, err
 	}

--- a/destination.go
+++ b/destination.go
@@ -79,14 +79,14 @@ func (d *Destination) Open(ctx context.Context) (err error) {
 }
 
 func (d *Destination) Write(ctx context.Context, records []sdk.Record) (int, error) {
-	batches, err := parseRecords(d.writer, records)
+	batches, err := parseRecords(records)
 	if err != nil {
 		return 0, err
 	}
 
 	var written int
 	for _, batch := range batches {
-		batchWrittenRecs, err := batch.writeBatch(ctx)
+		batchWrittenRecs, err := batch.writeBatch(ctx, d.writer)
 		written += batchWrittenRecs
 		if err != nil {
 			return written, err

--- a/destination.go
+++ b/destination.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	sdk "github.com/conduitio/conduit-connector-sdk"
+	"github.com/pinecone-io/go-pinecone/pinecone"
 )
 
 type Destination struct {
@@ -79,17 +80,58 @@ func (d *Destination) Open(ctx context.Context) (err error) {
 }
 
 func (d *Destination) Write(ctx context.Context, records []sdk.Record) (int, error) {
+	var deleteIds []string
+	var upsertVecs []*pinecone.Vector
+
+	addVec := func(record sdk.Record) error {
+		id := recordID(record.Key)
+
+		payload, err := parseRecordPayload(record.Payload)
+		if err != nil {
+			return fmt.Errorf("error getting payload: %w", err)
+		}
+
+		metadata, err := recordMetadata(record.Metadata)
+		if err != nil {
+			return fmt.Errorf("error getting metadata: %w", err)
+		}
+
+		vec := &pinecone.Vector{
+			//revive:disable-next-line
+			Id:           id,
+			Values:       payload.Values,
+			SparseValues: payload.PineconeSparseValues(),
+			Metadata:     metadata,
+		}
+
+		upsertVecs = append(upsertVecs, vec)
+		return nil
+	}
+
 	for i, record := range records {
-		err := sdk.Util.Destination.Route(ctx, record,
-			d.writer.Upsert,
-			d.writer.Upsert,
-			d.writer.Delete,
-			d.writer.Upsert,
-		)
+		var err error
+		switch record.Operation {
+		case sdk.OperationCreate:
+			err = addVec(record)
+		case sdk.OperationUpdate:
+			err = addVec(record)
+		case sdk.OperationDelete:
+			id := string(record.Key.Bytes())
+			deleteIds = append(deleteIds, id)
+		case sdk.OperationSnapshot:
+			err = addVec(record)
+		}
 		if err != nil {
 			return i, fmt.Errorf("route %s: %w", record.Operation.String(), err)
 		}
 		sdk.Logger(ctx).Trace().Msgf("wrote record op %s", record.Operation.String())
+	}
+
+	if len(upsertVecs) != 0 {
+		d.writer.UpsertVectors(ctx, upsertVecs)
+	}
+	if len(deleteIds) != 0 {
+		d.writer.DeleteRecords(ctx, deleteIds)
 	}
 
 	return len(records), nil

--- a/writer.go
+++ b/writer.go
@@ -125,7 +125,7 @@ func parseVector(rec sdk.Record) (*pinecone.Vector, error) {
 		return nil, err
 	}
 
-	metadata, err := parseRecordMetadata(rec)
+	metadata, err := parsePineconeMetadata(rec)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func parseRecordPayload(rec sdk.Record) (parsed recordPayload, err error) {
 	return parsed, nil
 }
 
-func parseRecordMetadata(rec sdk.Record) (*pinecone.Metadata, error) {
+func parsePineconeMetadata(rec sdk.Record) (*pinecone.Metadata, error) {
 	convertedMap := make(map[string]any)
 	for key, value := range rec.Metadata {
 		if trimmed, hasPrefix := trimPineconeKey(key); hasPrefix {
@@ -206,12 +206,12 @@ func (b deleteBatch) writeBatch(ctx context.Context, writer *Writer) (int, error
 	return len(b.ids), nil
 }
 
-// parseRecords processes a slice of records and groups them into batches based
+// buildBatches processes a slice of records and groups them into batches based
 // on their operation type. New batches are started whenever the operation type
 // switches from upsert to delete or vice versa.
 // Records are batched this way so that we preserve conduit's requirement of writing
 // records sequentially.
-func parseRecords(records []sdk.Record) ([]recordBatch, error) {
+func buildBatches(records []sdk.Record) ([]recordBatch, error) {
 	var batches []recordBatch
 	var currUpsertBatch upsertBatch
 	var currDeleteBatch deleteBatch

--- a/writer.go
+++ b/writer.go
@@ -101,7 +101,6 @@ type recordPayload struct {
 	ID           string       `json:"id"`
 	Values       []float32    `json:"values"`
 	SparseValues sparseValues `json:"sparse_values,omitempty"`
-	Namespace    string       `json:"namespace"`
 }
 
 func (r recordPayload) PineconeSparseValues() *pinecone.SparseValues {

--- a/writer.go
+++ b/writer.go
@@ -71,8 +71,8 @@ func (w *Writer) UpsertVectors(ctx context.Context, vectors []*pinecone.Vector) 
 	return int(upserted), nil
 }
 
-func (w *Writer) DeleteVectorsById(ctx context.Context, vectorIds []string) error {
-	err := w.index.DeleteVectorsById(&ctx, vectorIds)
+func (w *Writer) DeleteVectorsByID(ctx context.Context, vectorIDs []string) error {
+	err := w.index.DeleteVectorsById(&ctx, vectorIDs)
 	if err != nil {
 		return fmt.Errorf("error deleting record: %w", err)
 	}
@@ -198,7 +198,7 @@ type deleteBatch struct {
 }
 
 func (b deleteBatch) writeBatch(ctx context.Context, writer *Writer) (int, error) {
-	err := writer.DeleteVectorsById(ctx, b.ids)
+	err := writer.DeleteVectorsByID(ctx, b.ids)
 	if err != nil {
 		return 0, err
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -82,7 +82,7 @@ func TestParseRecords(t *testing.T) {
 		testRecord(sdk.OperationSnapshot), testRecord(sdk.OperationSnapshot),
 	}
 
-	batches, err := parseRecords(nil, records)
+	batches, err := parseRecords(records)
 	is.NoErr(err)
 
 	is.Equal(len(batches), 5)

--- a/writer_test.go
+++ b/writer_test.go
@@ -15,7 +15,6 @@
 package pinecone
 
 import (
-	"fmt"
 	"testing"
 
 	sdk "github.com/conduitio/conduit-connector-sdk"
@@ -33,8 +32,6 @@ func TestRecordMetadata(t *testing.T) {
 	}
 	recMetadata, err := parseRecordMetadata(rec)
 	is.NoErr(err)
-
-	fmt.Println()
 
 	is.Equal(recMetadata.Fields["prop1"].AsInterface().(string), "a1")
 	is.Equal(recMetadata.Fields["prop2"].AsInterface().(string), "a2")

--- a/writer_test.go
+++ b/writer_test.go
@@ -30,7 +30,7 @@ func TestRecordMetadata(t *testing.T) {
 		"pinecone.prop1": "a1",
 		"pinecone.prop2": "a2",
 	}
-	recMetadata, err := parseRecordMetadata(rec)
+	recMetadata, err := parsePineconeMetadata(rec)
 	is.NoErr(err)
 
 	is.Equal(recMetadata.Fields["prop1"].AsInterface().(string), "a1")
@@ -82,7 +82,7 @@ func TestParseRecords(t *testing.T) {
 		testRecord(sdk.OperationSnapshot), testRecord(sdk.OperationSnapshot),
 	}
 
-	batches, err := parseRecords(records)
+	batches, err := buildBatches(records)
 	is.NoErr(err)
 
 	is.Equal(len(batches), 5)

--- a/writer_test.go
+++ b/writer_test.go
@@ -25,16 +25,74 @@ import (
 func TestRecordMetadata(t *testing.T) {
 	is := is.New(t)
 
-	sdkMetadata := sdk.Metadata{
+	var rec sdk.Record
+	rec.Metadata = sdk.Metadata{
 		"created_at":     "2023-03-15T14:25:07Z",
 		"pinecone.prop1": "a1",
 		"pinecone.prop2": "a2",
 	}
-	recMetadata, err := recordMetadata(sdkMetadata)
+	recMetadata, err := parseRecordMetadata(rec)
 	is.NoErr(err)
 
 	fmt.Println()
 
 	is.Equal(recMetadata.Fields["prop1"].AsInterface().(string), "a1")
 	is.Equal(recMetadata.Fields["prop2"].AsInterface().(string), "a2")
+}
+
+func testRecord(op sdk.Operation) sdk.Record {
+	var position sdk.Position
+	var key sdk.Data = sdk.RawData("key")
+	var metadata sdk.Metadata
+	var payload sdk.Data = sdk.StructuredData{
+		"vector": []float64{1, 2},
+	}
+
+	return sdk.Record{
+		Position: position, Operation: op,
+		Metadata: metadata, Key: key,
+		Payload: sdk.Change{
+			Before: nil,
+			After:  payload,
+		},
+	}
+}
+
+func batchSize(batch recordBatch) int {
+	switch batch := batch.(type) {
+	case upsertBatch:
+		return len(batch.vectors)
+	case deleteBatch:
+		return len(batch.ids)
+	}
+
+	panic("invalid batch")
+}
+
+func TestParseRecords(t *testing.T) {
+	is := is.New(t)
+
+	records := []sdk.Record{
+		testRecord(sdk.OperationUpdate),
+
+		testRecord(sdk.OperationDelete), testRecord(sdk.OperationDelete),
+
+		testRecord(sdk.OperationCreate), testRecord(sdk.OperationCreate),
+		testRecord(sdk.OperationCreate),
+
+		testRecord(sdk.OperationDelete),
+
+		testRecord(sdk.OperationSnapshot), testRecord(sdk.OperationSnapshot),
+	}
+
+	batches, err := parseRecords(nil, records)
+	is.NoErr(err)
+
+	is.Equal(len(batches), 5)
+
+	is.Equal(batchSize(batches[0]), 1)
+	is.Equal(batchSize(batches[1]), 2)
+	is.Equal(batchSize(batches[2]), 3)
+	is.Equal(batchSize(batches[3]), 1)
+	is.Equal(batchSize(batches[4]), 2)
 }


### PR DESCRIPTION
### Description

Stacked from #20 

Allows batching records.

NOTE: missing unit tests, this is proof of concept. Passes my integration tests on my machine, where I have secrets properly set up. Integration tests won't pass on ci because we still have missing pinecone api keys.