### PR TITLE
add missing Parameters() method

### DIFF
--- a/destination.go
+++ b/destination.go
@@ -62,6 +62,10 @@ func NewDestination() sdk.Destination {
 	return sdk.DestinationWithMiddleware(&Destination{}, sdk.DefaultDestinationMiddleware()...)
 }
 
+func (d *Destination) Parameters() map[string]sdk.Parameter {
+	return d.config.Parameters()
+}
+
 func (d *Destination) Configure(ctx context.Context, cfg map[string]string) (err error) {
 	if err = sdk.Util.ParseConfig(cfg, &d.config); err != nil {
 		return fmt.Errorf("invalid config: %w", err)


### PR DESCRIPTION
### Description

The implementation did not have a `.Parameters()` method, so here it is.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio/conduit-connector-pinecone/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.